### PR TITLE
Vue Charts bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "chart.js": "^3.7.1",
     "core-js": "^3.8.3",
     "dotenv": "^16.0.0",
+    "just-clone": "^5.0.1",
     "pinia": "^2.0.13",
     "vue": "^3.2.13",
     "vue-chartjs": "^4.0.7",

--- a/src/components/additionalAdds/Stock-chart.vue
+++ b/src/components/additionalAdds/Stock-chart.vue
@@ -16,6 +16,7 @@
 
 <script>
 import { Line as LineChartGenerator } from 'vue-chartjs'
+import clone from 'just-clone'
 
 import {
   Chart as ChartJS,

--- a/src/components/additionalAdds/Stock-chart.vue
+++ b/src/components/additionalAdds/Stock-chart.vue
@@ -86,24 +86,6 @@ export default {
   },
   data() {
     return {
-      chartData: {
-        labels: this.timeLabels,
-        datasets: [
-          {
-            label: 'Closing Price',
-            backgroundColor: [
-              'green'
-            ],
-            data: this.closingPrices,
-            borderColor: [
-              'rgba(255, 255, 255, 0.9)'
-            ],
-            fill: true,
-            pointRadius: 0,
-            borderWidth: 2.5
-          }
-        ]
-      },
       chartOptions: {
         maintainAspectRatio: false,
         scales: {
@@ -134,6 +116,25 @@ export default {
           }
         },
       },
+    }
+  },
+
+  computed: {
+    chartData() {
+      return clone({
+        labels: this.timeLabels,
+        datasets: [
+          {
+            label: 'Closing Price',
+            backgroundColor: ['green'],
+            data: this.closingPrices,
+            borderColor: ['rgba(255, 255, 255, 0.9)'],
+            fill: true,
+            pointRadius: 0,
+            borderWidth: 2.5
+          }
+        ]
+      })
     }
   }
 }


### PR DESCRIPTION
# Description

This PR addresses an issue with the Vue Charts hitting a `maximum call stack exceeded` error. 

There are two primary changes: 

1. Adds a dependency free package called `just-clone` was added to the project. You'll need to run `npm install` if you merge this PR in order for this to work. Or manually install the package with `npm install just-clone`. 

I'd recommend checking out these awesome utility functions. Deeply cloning an object is a semi-common thing to do in JS, and this util provides a nice utility to do that. But there are ton of other useful functions (great for learning too): https://github.com/angus-c/just#the-modules-package

2. Implements a computed prop that clones (or creates) a _totally new_ `chartData` object. This was needed because Vue Charts doesn't work reactively, and can't distinguish when you're modifying deeply nested property inside of the `options` object. However, it _can_ tell when you pass in an entirely new object, per the docs: 3. 

<img width="818" alt="Screen Shot 2022-04-28 at 9 50 00 AM" src="https://user-images.githubusercontent.com/20786477/165780967-1a0ac874-3fa4-4028-9637-1a2bccf97f8d.png">

https://vue-chartjs.org/guide/#updating-charts

One thing I forgot to mention: The "issues" section of a Github project can be a great place to search around if you're blocked on a problem. And if you're really blocked, you can even ask a question there yourself. I noticed that someone else had a similar issue: 

https://github.com/apertureless/vue-chartjs/issues/197
